### PR TITLE
Improve websocket handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ const socketServer = new WebSocket.Server({ port: 8081 });
 let connections = [];
 socketServer.on('connection', connection => {
   connections.push(connection);
-	connection.on('error', () => {});
+  connection.on('error', () => {});
   connection.on('close', () => connections.splice(connections.indexOf(connection)));
 });
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ watch(source).
     }
   });
 
-const socketServer = new WebSocket.Server({ port: 8081 });
+const socketServer = new WebSocket.Server({ port: port + 1 });
 let connections = [];
 socketServer.on('connection', connection => {
   connections.push(connection);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -98,7 +98,9 @@
     </script>
 
     <script>
-      var ws = new WebSocket('ws://localhost:8081');
+      var host = location.hostname
+      var port = parseInt(location.port, 10) + 1
+      var ws = new WebSocket('ws://' + host + ':' + port);
       ws.onmessage = function() { window.location.reload(); };
     </script>
 


### PR DESCRIPTION
Should fix issue https://github.com/bjornbytes/lovr-webvr-server/issues/2

Detailed explanation

Websocket worked fine for local development but two issues arise
as soon as the server and the client were on different machine.

1. The hostname is fixed to localhost, which won't work if the file
   are served from say 192.168.1.25

2. The port is fixed to 8081 which might cause issue if the server
   is asked to run on that port and will cause issue if the server
   machine didn't open the port 8081.

Both fix require editing the same line in the view and I stumbled
upon both issue at once so I fix both in the same commit. Current
solution for the port issue is to use the HTTP port + 1. Things stay
the same for the default case, solve the issue of starting express
on port 8081 and fix my issue as home server have port 5000 to 5999
open.